### PR TITLE
FEATURE: remove baidu browser support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,7 @@ module.exports = [
   'last 2 UCAndroid versions',
   // Others
   'last 2 Electron versions',
-  'last 2 Samsung versions',
-  'last 2 Baidu versions'
+  'last 2 Samsung versions'
 ];
 
-// Not supported: BlackBerry, OperaMini, Android, ExplorerMobile, Explorer, kaios, OperaMobile
+// Not supported: BlackBerry, OperaMini, Android, ExplorerMobile, Explorer, kaios, OperaMobile, Baidu

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -56,7 +56,6 @@ describe('browserslist-config', () => {
   it('should contain special browsers', () => {
     expect(clearedConfig.indexOf('Electron')).toBe(11);
     expect(clearedConfig.indexOf('Samsung')).toBe(12);
-    expect(clearedConfig.indexOf('Baidu')).toBe(13);
   });
 
   it('should NOT contain unnecessary browsers', () => {
@@ -66,5 +65,6 @@ describe('browserslist-config', () => {
     expect(clearedConfig.indexOf('Explorer')).toBe(-1);
     expect(clearedConfig.indexOf('kaios')).toBe(-1);
     expect(clearedConfig.indexOf('OperaMobile')).toBe(-1);
+    expect(clearedConfig.indexOf('Baidu')).toBe(-1);
   });
 });


### PR DESCRIPTION
baidu is deprecated since 2019 - no clue why we ever supported this browser 😂 